### PR TITLE
Fix certificate generation

### DIFF
--- a/jobs/mongod/templates/bin/generate_ssl_cert.sh.erb
+++ b/jobs/mongod/templates/bin/generate_ssl_cert.sh.erb
@@ -1,40 +1,40 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
-source `dirname $(readlink -f $0)`/setenv
+source "$(dirname "$(readlink -f "$0")")/setenv"
 
-pushd `dirname $(readlink -f $0)` >/dev/null
-cd ${MONGODB_SSL}
+cd "${MONGODB_SSL}" || exit 666
 
 # generate only if client and server keys doesnt already exists
-if [ ! -f ${MONGODB_SSL}/mongodb.pem ]
-then
-	<%- mongo__current_ip = spec.ip -%>
+if [ ! -f "${MONGODB_SSL}/mongodb.pem" ]; then
 
-	# retrieving openssl.cnf - location is OS ependent
-	OPENSSL_CNF=`find /etc -name 'openssl.cnf'`
+    # retrieving openssl.cnf - location is OS ependent
+    OPENSSL_CNF=$(find /etc -name openssl.cnf)
 
-    openssl genrsa -out ${MONGODB_SSL}/mongodb.key 2048
+    # generate private key
+    openssl genrsa -out "${MONGODB_SSL}/mongodb.key" 2048
     
-    openssl req -new -key ${MONGODB_SSL}/mongodb.key \
-	    -out ${MONGODB_SSL}/mongodb.csr \
-	    -reqexts SAN \
-		-extensions SAN \
-		-config <(cat ${OPENSSL_CNF} \
-          <(printf "[SAN]\nsubjectAltName=IP.1:<%= mongo__current_ip -%>,IP.2:127.0.0.1\nextendedKeyUsage=serverAuth,clientAuth")) \
-	    -subj "/C=FR/ST=Paris/L=Paris/O=Orange/OU=CloudFoundry/CN=<%= mongo__current_ip -%>"
-	    
-    openssl x509 -req -in ${MONGODB_SSL}/mongodb.csr \
-	    -CA ${MONGODB_SSL}/CA.crt \
-	    -CAkey ${MONGODB_SSL}/CA.key \
-	    -CAcreateserial -out ${MONGODB_SSL}/mongodb.crt \
-	    -days 3650 -sha256
+    SAN_SECTION="[SAN]\nsubjectAltName=IP:<%= spec.ip %>,IP:127.0.0.1\nextendedKeyUsage=serverAuth,clientAuth\n"
 
-    cat ${MONGODB_SSL}/mongodb.key \
-    	${MONGODB_SSL}/mongodb.crt > ${MONGODB_SSL}/mongodb.pem
+    # generate certification request
+    openssl req -new -key "${MONGODB_SSL}/mongodb.key" \
+        -out "${MONGODB_SSL}/mongodb.csr" \
+        -reqexts SAN \
+        -config <(cat "${OPENSSL_CNF}" <(printf "${SAN_SECTION}")) \
+        -subj "/C=FR/ST=Paris/L=Paris/O=Orange/OU=CloudFoundry/CN=<%= spec.ip %>"
+
+    # sign certificate
+    openssl x509 -req -in "${MONGODB_SSL}/mongodb.csr" \
+        -extensions SAN \
+        -extfile <(printf "${SAN_SECTION}") \
+        -CA "${MONGODB_SSL}/CA.crt" \
+        -CAkey "${MONGODB_SSL}/CA.key" \
+        -CAcreateserial -out "${MONGODB_SSL}/mongodb.crt" \
+        -days 3650 -sha256
+
+    cat "${MONGODB_SSL}/mongodb.key" \
+        "${MONGODB_SSL}/mongodb.crt" \
+        > "${MONGODB_SSL}/mongodb.pem"
 fi
-
-popd >/dev/null
-exit 0


### PR DESCRIPTION
Hi Jérémy,

Here in this PR, we stop stripping X509 v3 extensions when signing the MongoDB server certificates.
We also improve quoting, indenting and various other style aspects.

**Attention:** this PR merges in the `feature-ssl` branch and you have many branches on top of it. So you might need to rebase all these branches in order to benefit from these improvements in your latest work. It's up to you!

Cheers